### PR TITLE
fix: ensure the schema upgrade is correctly handled for new variants

### DIFF
--- a/crates/processors/src/processors/upgrade_model.rs
+++ b/crates/processors/src/processors/upgrade_model.rs
@@ -137,9 +137,12 @@ where
             unpacked_size,
             block_timestamp,
             Some(&schema_diff),
-            // This will be Some if we have an "upgrade" diff. Which means
-            // if some columns have been modified.
-            prev_schema.diff(&new_schema).as_ref(),
+            // Ensures the diff is always Some, which should be the case if we have an "upgrade"
+            // diff. Which means if some columns have been modified.
+            // Since a column may not exist in the previous schema, the diff from prev_schema to
+            // new_schema will be None. To ensure we always have a diff, we use the schema_diff if
+            // the diff from prev_schema to new_schema is None.
+            prev_schema.diff(&new_schema).as_ref().or(Some(&schema_diff)),
         )
         .await?;
 


### PR DESCRIPTION
Closes #71.

This PR ensures that the new variants of an enum are not ignored during the upgrade.

The subscription was actually working for the optimistic broadcast. However the DB wasn't actually updated, since the diff of the schema was `None`.

Integration tests will be merged with the current work on integration test for the cursors being done on my end. 👍 