### PR TITLE
fix(processors/controller): ensure all controllers are fetched and remove false positive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11454,6 +11454,8 @@ dependencies = [
  "hashlink",
  "ipfs-api-backend-hyper",
  "lazy_static",
+ "reqwest",
+ "serde",
  "serde_json",
  "starknet 0.12.0",
  "starknet-crypto 0.7.4",

--- a/crates/processors/Cargo.toml
+++ b/crates/processors/Cargo.toml
@@ -26,3 +26,5 @@ torii-task-network.workspace = true
 thiserror.workspace = true
 ipfs-api-backend-hyper.workspace = true
 hashlink.workspace = true
+serde.workspace = true
+reqwest.workspace = true

--- a/crates/processors/src/error.rs
+++ b/crates/processors/src/error.rs
@@ -25,4 +25,6 @@ pub enum Error {
     CairoSerdeError(#[from] cainome::cairo_serde::Error),
     #[error(transparent)]
     JoinError(#[from] tokio::task::JoinError),
+    #[error(transparent)]
+    ControllerProcessorError(#[from] crate::processors::controller::ControllerProcessorError),
 }

--- a/crates/processors/src/processors/controller.rs
+++ b/crates/processors/src/processors/controller.rs
@@ -190,13 +190,13 @@ where
         info!(
             target: LOG_TARGET,
             username = %username,
-            address = %format!("{:#x}", udc_event.address),
+            address = %format!("{:#064x}", udc_event.address),
             "Controller deployed."
         );
 
         db.add_controller(
             &username,
-            &format!("{:#x}", udc_event.address),
+            &format!("{:#064x}", udc_event.address),
             block_timestamp,
         )
         .await?;

--- a/crates/processors/src/processors/controller.rs
+++ b/crates/processors/src/processors/controller.rs
@@ -161,19 +161,17 @@ where
             }
         };
 
+        let address = format!("{:#064x}", udc_event.address);
+
         info!(
             target: LOG_TARGET,
             username = %username,
-            address = %format!("{:#064x}", udc_event.address),
+            address = %address,
             "Controller deployed."
         );
 
-        db.add_controller(
-            &username,
-            &format!("{:#064x}", udc_event.address),
-            block_timestamp,
-        )
-        .await?;
+        db.add_controller(&username, &address, block_timestamp)
+            .await?;
 
         Ok(())
     }

--- a/crates/processors/src/processors/mod.rs
+++ b/crates/processors/src/processors/mod.rs
@@ -27,7 +27,7 @@ use upgrade_model::UpgradeModelProcessor;
 
 use crate::{BlockProcessor, EventProcessor, TransactionProcessor};
 
-mod controller;
+pub(crate) mod controller;
 mod erc1155_transfer_batch;
 mod erc1155_transfer_single;
 mod erc20_legacy_transfer;


### PR DESCRIPTION
@Larkooo this revamped version of the controller processor allows to avoid all the false positives, without having to fetch the controller classes too often.

By syncing the whole mainnet events, there are only 800 fetches on the approx 1M events of the UDC. The fetches are mostly at the beginning of the network, once we reach the first controllers, false positives are actually less.

I've added the corresponding tests with links to real events to keep some references.

This PR also pads the addresses to ensure the lookup by addresses is easier matching exact values from a client perspective.