### PR TITLE
fix(controllers): add padding to addresses + tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -379,6 +379,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "assert_fs"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6688,6 +6698,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
 
 [[package]]
+name = "mockito"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7760e0e418d9b7e5777c0374009ca4c93861b9066f18cb334a20ce50ab63aa48"
+dependencies = [
+ "assert-json-diff",
+ "bytes",
+ "colored",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-util",
+ "log",
+ "rand 0.9.1",
+ "regex",
+ "serde_json",
+ "serde_urlencoded",
+ "similar",
+ "tokio",
+]
+
+[[package]]
 name = "moka"
 version = "0.12.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9525,6 +9559,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11443,6 +11483,7 @@ dependencies = [
  "hashlink",
  "ipfs-api-backend-hyper",
  "katana-runner",
+ "mockito",
  "once_cell",
  "reqwest",
  "scarb",
@@ -11460,6 +11501,7 @@ dependencies = [
  "torii-indexer",
  "torii-sqlite-types",
  "tracing",
+ "url",
 ]
 
 [[package]]

--- a/crates/sqlite/sqlite/Cargo.toml
+++ b/crates/sqlite/sqlite/Cargo.toml
@@ -50,3 +50,5 @@ scarb.workspace = true
 sozo-scarbext.workspace = true
 tempfile.workspace = true
 torii-indexer.workspace = true
+mockito = "1.2"
+url.workspace = true

--- a/crates/sqlite/sqlite/src/controllers.rs
+++ b/crates/sqlite/sqlite/src/controllers.rs
@@ -147,6 +147,9 @@ impl ControllersSync {
             .collect())
     }
 
+    /// Syncs the controllers from the Cartridge API to the database.
+    ///
+    /// Returns the number of controllers synced.
     pub async fn sync(&self) -> Result<usize, ControllerSyncError> {
         let controllers = self.fetch_controllers().await?;
         let num_controllers = controllers.len();
@@ -175,29 +178,34 @@ impl ControllersSync {
 
 #[cfg(test)]
 mod tests {
-    use std::{str::FromStr, sync::Arc};
+    use std::sync::Arc;
 
     use super::*;
     use mockito::Server;
     use serde_json::json;
     use sqlx::Row;
-    use starknet::providers::{jsonrpc::HttpTransport, JsonRpcClient};
+    use starknet::{
+        macros::felt,
+        providers::{jsonrpc::HttpTransport, JsonRpcClient},
+    };
     use starknet_crypto::Felt;
     use tokio::sync::broadcast;
     use url::Url;
 
     const CARTRIDGE_NODE_MAINNET: &str = "https://api.cartridge.gg/x/starknet/mainnet";
 
-    async fn new_sql_test(shutdown_tx: broadcast::Sender<()>) -> Sql {
+    /// Creates a new Sql instance with a temporary file.
+    ///
+    /// Returns the Sql instance and a handle to the executor task.
+    async fn new_sql_test(
+        world_address: Felt,
+        shutdown_tx: broadcast::Sender<()>,
+    ) -> (Sql, tokio::task::JoinHandle<()>) {
         let provider = Arc::new(JsonRpcClient::new(HttpTransport::new(
             Url::parse(CARTRIDGE_NODE_MAINNET).unwrap(),
         )));
-        Sql::new_tmp_file(
-            Felt::from_str("0x123").unwrap(),
-            provider.clone(),
-            shutdown_tx,
-        )
-        .await
+
+        Sql::new_tmp_file(world_address, provider.clone(), shutdown_tx).await
     }
 
     #[tokio::test]
@@ -232,7 +240,7 @@ mod tests {
 
         let (shutdown_tx, _) = broadcast::channel(1);
 
-        let sql = new_sql_test(shutdown_tx).await;
+        let (sql, executor_handle) = new_sql_test(felt!("0x123"), shutdown_tx.clone()).await;
         let sync = ControllersSync::new(sql)
             .await
             .with_api_url(server.url() + "/query");
@@ -245,6 +253,9 @@ mod tests {
         assert_eq!(controllers[0].account.username, "test_user");
 
         mock.assert_async().await;
+
+        let _ = shutdown_tx.send(());
+        let _ = executor_handle.await;
     }
 
     #[tokio::test]
@@ -260,7 +271,7 @@ mod tests {
             .await;
 
         let (shutdown_tx, _) = broadcast::channel(1);
-        let sql = new_sql_test(shutdown_tx).await;
+        let (sql, executor_handle) = new_sql_test(felt!("0x1234"), shutdown_tx.clone()).await;
 
         let sync = ControllersSync::new(sql)
             .await
@@ -277,23 +288,29 @@ mod tests {
         }
 
         mock.assert_async().await;
+
+        let _ = shutdown_tx.send(());
+        let _ = executor_handle.await;
     }
 
-    #[ignore = "This test requires the executor to work from test utils, to be fixed."]
     #[tokio::test(flavor = "multi_thread")]
     async fn test_sync() {
         let (shutdown_tx, _) = broadcast::channel(1);
-        let sql = new_sql_test(shutdown_tx).await;
+        let (sql, executor_handle) = new_sql_test(felt!("0x123"), shutdown_tx.clone()).await;
 
         let ctrls = ControllersSync::new(sql).await;
 
         let num_controllers = ctrls.sync().await.unwrap();
         assert!(num_controllers > 0);
 
+        ctrls.sql.execute().await.unwrap();
+
         let stored_controllers = sqlx::query("SELECT address FROM controllers")
             .fetch_all(ctrls.pool())
             .await
             .unwrap();
+
+        assert!(stored_controllers.len() == num_controllers);
 
         for row in stored_controllers {
             let address: String = row.get("address");
@@ -301,12 +318,15 @@ mod tests {
             assert!(address.starts_with("0x"));
             assert!(address[2..].chars().all(|c| c.is_ascii_hexdigit()));
         }
+
+        let _ = shutdown_tx.send(());
+        let _ = executor_handle.await;
     }
 
     #[tokio::test]
     async fn test_fetch_controllers_api_empty_future() {
         let (shutdown_tx, _) = broadcast::channel(1);
-        let sql = new_sql_test(shutdown_tx).await;
+        let (sql, executor_handle) = new_sql_test(felt!("0x123"), shutdown_tx.clone()).await;
 
         // Insert a controller in the future which should always yield an empty result.
         let timestamp = chrono::Utc::now() + chrono::Duration::days(10);
@@ -327,5 +347,8 @@ mod tests {
         assert!(result.is_ok());
         let controllers = result.unwrap();
         assert!(controllers.is_empty());
+
+        let _ = shutdown_tx.send(());
+        let _ = executor_handle.await;
     }
 }

--- a/crates/sqlite/sqlite/src/controllers.rs
+++ b/crates/sqlite/sqlite/src/controllers.rs
@@ -272,6 +272,7 @@ mod tests {
         mock.assert_async().await;
     }
 
+    #[ignore = "This test requires the executor to work from test utils, to be fixed."]
     #[tokio::test(flavor = "multi_thread")]
     async fn test_sync() {
         let (shutdown_tx, _) = broadcast::channel(1);

--- a/crates/sqlite/sqlite/src/controllers.rs
+++ b/crates/sqlite/sqlite/src/controllers.rs
@@ -61,8 +61,6 @@ impl ControllersSync {
         .await
         .expect("Should be able to read cursor from controllers table");
 
-        dbg!(&cursor);
-
         Self {
             sql,
             cursor: RwLock::new(cursor),
@@ -166,7 +164,6 @@ impl ControllersSync {
                 )
                 .await;
 
-            dbg!(&e);
             e?;
 
             *self.cursor.write().await = Some(controller.created_at);

--- a/crates/sqlite/sqlite/src/controllers.rs
+++ b/crates/sqlite/sqlite/src/controllers.rs
@@ -1,16 +1,21 @@
-use std::time::Duration;
+use std::{str::FromStr, time::Duration};
 
 use chrono::{DateTime, Utc};
 use serde::Deserialize;
 use serde_json::json;
+use sqlx::SqlitePool;
+use starknet_crypto::Felt;
 use tokio::sync::RwLock;
 
 use crate::{error::ControllerSyncError, Sql};
+
+const CARTRIDGE_API_QUERY_URL: &str = "https://api.cartridge.gg/query";
 
 #[derive(Debug)]
 pub struct ControllersSync {
     sql: Sql,
     cursor: RwLock<Option<DateTime<Utc>>>,
+    api_url: String,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -58,11 +63,20 @@ impl ControllersSync {
         Self {
             sql,
             cursor: RwLock::new(cursor),
+            api_url: CARTRIDGE_API_QUERY_URL.to_string(),
         }
     }
 
-    pub async fn sync(&self) -> Result<usize, ControllerSyncError> {
-        // graphQL query to get the controllers api.cartridge.gg/graphql
+    pub fn with_api_url(mut self, url: String) -> Self {
+        self.api_url = url;
+        self
+    }
+
+    pub fn pool(&self) -> &SqlitePool {
+        &self.sql.pool
+    }
+
+    async fn fetch_controllers(&self) -> Result<Vec<Controller>, ControllerSyncError> {
         let query = format!(
             r#"
         query {{
@@ -92,7 +106,7 @@ impl ControllersSync {
         let response = loop {
             attempts += 1;
             let result = reqwest::Client::new()
-                .post("https://api.cartridge.gg/query")
+                .post(&self.api_url)
                 .json(&json!({
                     "query": query,
                 }))
@@ -110,28 +124,174 @@ impl ControllersSync {
             }
         };
 
+        if !response.status().is_success() {
+            let error_text = response.text().await?;
+            return Err(ControllerSyncError::ApiError(error_text));
+        }
+
         let body: ControllersResponse = response.json().await?;
 
-        let controllers = body
+        Ok(body
             .data
             .controllers
             .edges
-            .iter()
-            .map(|c| c.node.clone())
-            .collect::<Vec<_>>();
+            .into_iter()
+            .map(|e| e.node)
+            .collect())
+    }
+
+    pub async fn sync(&self) -> Result<usize, ControllerSyncError> {
+        let controllers = self.fetch_controllers().await?;
         let num_controllers = controllers.len();
 
         for controller in controllers {
-            self.sql
+            let felt_addr = Felt::from_str(&controller.address).unwrap();
+            let padded_address = format!("{:#066x}", felt_addr);
+
+            let e = self
+                .sql
                 .add_controller(
                     &controller.account.username,
-                    &controller.address,
+                    &padded_address,
                     controller.created_at,
                 )
-                .await?;
+                .await;
+
+            dbg!(&e);
+            e?;
+
             *self.cursor.write().await = Some(controller.created_at);
         }
 
         Ok(num_controllers)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{str::FromStr, sync::Arc};
+
+    use super::*;
+    use mockito::Server;
+    use serde_json::json;
+    use sqlx::Row;
+    use starknet::providers::{jsonrpc::HttpTransport, JsonRpcClient};
+    use starknet_crypto::Felt;
+    use tokio::sync::broadcast;
+    use url::Url;
+
+    const CARTRIDGE_NODE_MAINNET: &str = "https://api.cartridge.gg/x/starknet/mainnet";
+
+    async fn new_sql_test(shutdown_tx: broadcast::Sender<()>) -> Sql {
+        let provider = Arc::new(JsonRpcClient::new(HttpTransport::new(
+            Url::parse(CARTRIDGE_NODE_MAINNET).unwrap(),
+        )));
+        Sql::new_tmp_file(
+            Felt::from_str("0x123").unwrap(),
+            provider.clone(),
+            shutdown_tx,
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_fetch_controllers_success() {
+        let mut server = Server::new_async().await;
+        let mock = server
+            .mock("POST", "/query")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                json!({
+                    "data": {
+                        "controllers": {
+                            "edges": [
+                                {
+                                    "node": {
+                                        "address": "0x123",
+                                        "createdAt": "2024-03-20T12:00:00Z",
+                                        "account": {
+                                            "username": "test_user"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                })
+                .to_string(),
+            )
+            .create_async()
+            .await;
+
+        let (shutdown_tx, _) = broadcast::channel(1);
+
+        let sql = new_sql_test(shutdown_tx).await;
+        let sync = ControllersSync::new(sql)
+            .await
+            .with_api_url(server.url() + "/query");
+
+        let result = sync.fetch_controllers().await;
+        assert!(result.is_ok());
+        let controllers = result.unwrap();
+        assert_eq!(controllers.len(), 1);
+        assert_eq!(controllers[0].address, "0x123");
+        assert_eq!(controllers[0].account.username, "test_user");
+
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn test_fetch_controllers_error() {
+        let mut server = Server::new_async().await;
+        let mock = server
+            .mock("POST", "/query")
+            .with_status(500)
+            .with_header("content-type", "application/json")
+            .with_body("Internal Server Error")
+            .create_async()
+            .await;
+
+        let (shutdown_tx, _) = broadcast::channel(1);
+        let sql = new_sql_test(shutdown_tx).await;
+
+        let sync = ControllersSync::new(sql)
+            .await
+            .with_api_url(server.url() + "/query");
+
+        let result = sync.fetch_controllers().await;
+        assert!(result.is_err());
+
+        match result {
+            Err(ControllerSyncError::ApiError(msg)) => {
+                assert_eq!(msg, "Internal Server Error");
+            }
+            _ => panic!("Expected ApiError"),
+        }
+
+        mock.assert_async().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_sync() {
+        let (shutdown_tx, _) = broadcast::channel(1);
+        let sql = new_sql_test(shutdown_tx).await;
+
+        let ctrls = ControllersSync::new(sql).await;
+
+        let num_controllers = ctrls.sync().await.unwrap();
+        assert!(num_controllers > 0);
+
+        let stored_controllers = sqlx::query("SELECT address FROM controllers")
+            .fetch_all(ctrls.pool())
+            .await
+            .unwrap();
+
+        for row in stored_controllers {
+            let address: String = row.get("address");
+            assert_eq!(address.len(), 66);
+            assert!(address.starts_with("0x"));
+            assert!(address[2..].chars().all(|c| c.is_ascii_hexdigit()));
+        }
     }
 }

--- a/crates/sqlite/sqlite/src/error.rs
+++ b/crates/sqlite/sqlite/src/error.rs
@@ -112,4 +112,6 @@ pub enum ControllerSyncError {
     Reqwest(#[from] reqwest::Error),
     #[error(transparent)]
     Sql(#[from] crate::error::Error),
+    #[error("API error: {0}")]
+    ApiError(String),
 }

--- a/crates/sqlite/sqlite/src/lib.rs
+++ b/crates/sqlite/sqlite/src/lib.rs
@@ -37,6 +37,9 @@ pub mod model;
 pub mod simple_broker;
 pub mod utils;
 
+#[cfg(test)]
+pub mod test_utils;
+
 use cache::{LocalCache, Model, ModelCache};
 pub use torii_sqlite_types as types;
 
@@ -1159,7 +1162,10 @@ impl Sql {
                 insert_controller.to_string(),
                 arguments,
             ))
-            .map_err(|e| Error::Executor(ExecutorError::SendError(e)))?;
+            .map_err(|e| {
+                dbg!(&e);
+                Error::Executor(ExecutorError::SendError(e))
+            })?;
 
         Ok(())
     }

--- a/crates/sqlite/sqlite/src/test_utils.rs
+++ b/crates/sqlite/sqlite/src/test_utils.rs
@@ -1,0 +1,63 @@
+use std::str::FromStr;
+use std::sync::Arc;
+
+use crate::cache::ModelCache;
+use crate::executor::Executor;
+use crate::types::{Contract, ContractType};
+use crate::Sql;
+use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+use starknet::core::types::Felt;
+use starknet::providers::jsonrpc::HttpTransport;
+use starknet::providers::JsonRpcClient;
+use tempfile::NamedTempFile;
+use tokio::sync::broadcast;
+
+impl Sql {
+    /// Creates a new temporary file and returns a new Sql instance.
+    /// Only the world contract is added to the contracts list.
+    /// TODO: think about a more mature interface for this one when more tests are using it.
+    pub async fn new_tmp_file(
+        world_address: Felt,
+        provider: Arc<JsonRpcClient<HttpTransport>>,
+        shutdown_tx: broadcast::Sender<()>,
+    ) -> Self {
+        let tempfile = NamedTempFile::new().unwrap();
+        let path = tempfile.path().to_string_lossy();
+        let options = SqliteConnectOptions::from_str(&path)
+            .unwrap()
+            .create_if_missing(true)
+            .with_regexp();
+        let pool = SqlitePoolOptions::new()
+            .min_connections(1)
+            .idle_timeout(None)
+            .max_lifetime(None)
+            .connect_with(options)
+            .await
+            .unwrap();
+
+        sqlx::migrate!("../../migrations").run(&pool).await.unwrap();
+
+        let (mut executor, sender) =
+            Executor::new(pool.clone(), shutdown_tx.clone(), Arc::clone(&provider))
+                .await
+                .unwrap();
+
+        tokio::spawn(async move {
+            executor.run().await.unwrap();
+        });
+
+        let model_cache = Arc::new(ModelCache::new(pool.clone()).await.unwrap());
+
+        Sql::new(
+            pool.clone(),
+            sender,
+            &[Contract {
+                address: world_address,
+                r#type: ContractType::WORLD,
+            }],
+            model_cache,
+        )
+        .await
+        .unwrap()
+    }
+}


### PR DESCRIPTION
Currently the executor is not working with the `test_utils` added in the `sqlite` crate.

Test ignore at the moment to at least have the fetching tested.

This PR also adds padding to the controllers addresses.