### PR TITLE
fix(runner): relax Starknet RPC spec version check

### DIFF
--- a/crates/runner/src/lib.rs
+++ b/crates/runner/src/lib.rs
@@ -291,14 +291,25 @@ impl Runner {
         );
         let provider: Arc<_> = JsonRpcClient::new(transport).into();
 
-        // Check provider spec version. We only support v0.9.
+        // Check provider spec version. Torii supports v0.9.0; a mismatch is non-fatal.
         let supported_spec = "0.9";
-        let spec_version = provider.spec_version().await?;
-        if !spec_version.starts_with(supported_spec) {
-            return Err(anyhow::anyhow!(
-                "Provider spec version is not supported. Please use a provider that supports v{supported_spec}. Got: {spec_version}. You might need to add a `rpc/v{}` to the end of the URL.",
-                supported_spec.replace('.', "_")
-            ));
+        match provider.spec_version().await {
+            Ok(spec_version) => {
+                if !spec_version.starts_with(supported_spec) {
+                    warn!(
+                        target: LOG_TARGET,
+                        spec_version = %spec_version,
+                        "Provider spec version mismatch. Torii supports v0.9.0. Continuing anyway; you may experience unexpected behaviours.",
+                    );
+                }
+            }
+            Err(e) => {
+                warn!(
+                    target: LOG_TARGET,
+                    error = ?e,
+                    "Could not query Starknet RPC spec version. Torii supports v0.9.0. Continuing anyway; you may experience unexpected behaviours.",
+                );
+            }
         }
 
         // Verify contracts are deployed


### PR DESCRIPTION
## Summary

A node reporting a non-`0.9` `spec_version` (or failing to respond to `spec_version` at all) currently aborts torii startup at `crates/runner/src/lib.rs:294-302`. In practice most JSON-RPC methods torii uses are stable across minor spec bumps, so a strict prefix check blocks valid setups whenever a node ships a newer spec.

This PR replaces the hard error with a `tracing::warn!` and continues. The same softening also covers the `spec_version()` RPC call itself failing — that's downgraded from `?` to a warning, since a transient or malformed response shouldn't take down the indexer at startup. If the node really is incompatible, the failure will still surface at the actual RPC call site with a more specific error.

Mirrors dojoengine/dojo#3402 for sozo.

## Why warn instead of bumping the constant

The supported spec stays `"0.9"`. Bumping it requires verifying every RPC method torii calls against the new spec; warning + continuing is the safer way to unblock users today without committing to claims about untested specs.

## Test plan

- [x] `cargo build -p torii-runner` clean
- [x] `cargo install --path bin/torii --locked --force` clean
- [ ] Manual smoke: point torii at an RPC reporting a non-`0.9` spec; expect a `WARN torii:runner` line followed by normal startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)