### PR TITLE
fix(ci): install cargo-release with +stable toolchain

### DIFF
--- a/.github/workflows/release-dispatch.yml
+++ b/.github/workflows/release-dispatch.yml
@@ -26,12 +26,12 @@ jobs:
       - run: |
           VERSION=${{ inputs.version }}
           VERSION=${VERSION#v}
-          cargo install cargo-release --locked
+          cargo +stable install cargo-release --locked
           cargo release version $VERSION --execute --no-confirm && cargo release replace --execute --no-confirm
 
       - id: version_info
         run: |
-          cargo install cargo-get --locked
+          cargo +stable install cargo-get --locked
           echo "version=$(cargo get workspace.package.version)" >> $GITHUB_OUTPUT
 
       - uses: peter-evans/create-pull-request@v7


### PR DESCRIPTION
## Summary

The `release-dispatch` workflow's `cargo install cargo-release --locked` step fails because the repo's `rust-toolchain.toml` pins 1.90.0, which overrides the workflow's `stable` toolchain setup. The latest `cargo-release` (1.1.2) requires rustc 1.91+, so the build aborts:

```
error: cannot install package `cargo-release 1.1.2`, it requires rustc 1.91 or newer, while the currently active rustc version is 1.90.0
```

(Failed run: https://github.com/dojoengine/torii/actions/runs/26179260967)

## Fix

Use `cargo +stable install` for both helper CLIs (`cargo-release`, `cargo-get`). These tools don't compile this repo — they just consume/edit `Cargo.toml` — so there's no reason to honor the repo's pinned toolchain when building them. `+stable` sidesteps the override without touching `rust-toolchain.toml`. Applied to `cargo-get` proactively so the next MSRV bump doesn't break it the same way.
