### PR TITLE
fix(graphql): dedupe models across worlds when building schema

### DIFF
--- a/crates/graphql/src/schema.rs
+++ b/crates/graphql/src/schema.rs
@@ -179,7 +179,17 @@ async fn build_objects(pool: &SqlitePool) -> Result<(Vec<ObjectVariant>, Vec<Uni
     unions.push(erc_token_union);
 
     // model data objects
+    //
+    // When torii indexes multiple worlds, the same (namespace, name) model can
+    // be registered once per world, but GraphQL field/type names carry no
+    // world scope — async-graphql panics on the duplicate field ("Field `...`
+    // already exists"). Keep the first occurrence of each model name; the
+    // world-scoped views stay available through SQL and gRPC.
+    let mut seen_models = std::collections::HashSet::new();
     for model in &models {
+        if !seen_models.insert((model.namespace.clone(), model.name.clone())) {
+            continue;
+        }
         let schema: Ty = serde_json::from_str(&model.schema)
             .map_err(|e| anyhow::anyhow!(format!("Failed to parse model schema: {e}")))?;
         let type_mapping = build_type_mapping(&model.namespace, &schema);

--- a/crates/graphql/src/tests/mod.rs
+++ b/crates/graphql/src/tests/mod.rs
@@ -43,6 +43,7 @@ mod events_test;
 mod metadata_test;
 mod models_ordering_test;
 mod models_test;
+mod multi_world_schema_test;
 mod publish_message_test;
 mod subscription_test;
 

--- a/crates/graphql/src/tests/multi_world_schema_test.rs
+++ b/crates/graphql/src/tests/multi_world_schema_test.rs
@@ -1,0 +1,115 @@
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+    use std::sync::Arc;
+
+    use dojo_types::naming::get_tag;
+    use dojo_types::primitive::Primitive;
+    use dojo_types::schema::{Member, Struct, Ty};
+    use dojo_world::contracts::abigen::model::Layout;
+    use dojo_world::contracts::naming::compute_selector_from_tag;
+    use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+    use starknet::core::types::Felt;
+    use starknet::providers::jsonrpc::HttpTransport;
+    use starknet::providers::JsonRpcClient;
+    use tempfile::NamedTempFile;
+    use tokio::sync::broadcast;
+    use torii_messaging::Messaging;
+    use torii_sqlite::executor::Executor;
+    use torii_sqlite::Sql;
+    use torii_storage::proto::{ContractDefinition, ContractType};
+    use torii_storage::Storage;
+
+    use crate::schema::build_schema;
+
+    /// When torii indexes multiple worlds, the same (namespace, name) model is
+    /// registered once per world. GraphQL field names carry no world scope, so
+    /// building the schema used to panic on the duplicate field
+    /// ("Field `...` already exists") and take the process down.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn multi_world_duplicate_models_schema_builds() {
+        let tempfile = NamedTempFile::new().unwrap();
+        let path = tempfile.path().to_string_lossy();
+        let options = SqliteConnectOptions::from_str(&path)
+            .unwrap()
+            .create_if_missing(true)
+            .with_regexp();
+        let pool = SqlitePoolOptions::new().connect_with(options).await.unwrap();
+        sqlx::migrate!("../migrations").run(&pool).await.unwrap();
+
+        let provider = Arc::new(JsonRpcClient::new(HttpTransport::new(
+            starknet::providers::Url::parse("http://localhost:1").unwrap(),
+        )));
+
+        let (shutdown_tx, _) = broadcast::channel(1);
+        let (mut executor, sender) =
+            Executor::new(pool.clone(), shutdown_tx.clone(), Arc::clone(&provider))
+                .await
+                .unwrap();
+        tokio::spawn(async move {
+            executor.run().await.unwrap();
+        });
+
+        let world_a = Felt::ONE;
+        let world_b = Felt::TWO;
+        let contracts = &[
+            ContractDefinition {
+                address: world_a,
+                r#type: ContractType::WORLD,
+                starting_block: None,
+            },
+            ContractDefinition {
+                address: world_b,
+                r#type: ContractType::WORLD,
+                starting_block: None,
+            },
+        ];
+        let db = Sql::new(pool.clone(), sender, contracts).await.unwrap();
+
+        // the same model, once per world — e.g. two instances of the same game
+        let tag = get_tag("multiworld_test", "Duplicate");
+        for world_address in [world_a, world_b] {
+            db.register_model(
+                world_address,
+                compute_selector_from_tag(&tag),
+                &Ty::Struct(Struct {
+                    name: tag.clone(),
+                    children: vec![Member {
+                        name: "id".to_string(),
+                        key: true,
+                        ty: Ty::Primitive(Primitive::U32(None)),
+                    }],
+                }),
+                &Layout::Fixed(vec![]),
+                Felt::ONE,
+                Felt::TWO,
+                0,
+                0,
+                1710754478_u64,
+                None,
+                None,
+                true,
+            )
+            .await
+            .unwrap();
+        }
+        db.execute().await.unwrap();
+
+        let messaging = Arc::new(Messaging::new(
+            Default::default(),
+            Arc::new(db.clone()),
+            provider,
+        ));
+        let schema = build_schema(&pool, messaging, Arc::new(db.clone()))
+            .await
+            .expect("schema must build with the same model registered by two worlds");
+
+        let sdl = schema.sdl();
+        let field = "multiworldTestDuplicateModels";
+        assert_eq!(
+            sdl.matches(field).count() > 0,
+            true,
+            "model field missing from schema"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #433.

When torii indexes multiple worlds that register the same `(namespace, name)` model — e.g. several instances of one game deployed from the same code — `build_objects()` derives duplicate GraphQL field names and async-graphql panics (`Field `...` already exists`), killing the whole process, indexer included.

This dedupes models by `(namespace, name)` when building the schema. World-scoped access remains available via SQL and gRPC; single-world deployments are unaffected (the dedupe is a no-op there).

## Test

Adds a regression test that registers the same model under two world addresses and asserts the schema builds with the model field present.

- Without the fix: `panicked at async-graphql-7.0.11/src/dynamic/object.rs:82:9: Field `multiworldTestDuplicateModels` already exists`
- With the fix: `test result: ok. 1 passed`

Reproduced originally on torii v1.8.16 + katana v1.8.0-rc.9 with two `sozo migrate` runs of the same project under different seeds and one torii indexing both worlds. We run this patch in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)